### PR TITLE
:bug: Fix error on package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gatsby Kea Starter",
+  "name": "gatsby-kea-starter",
   "description": "Gatsby starter with redux and sagas made simpler by https://kea.js.org",
   "version": "1.0.0",
   "author": "Benjamin Glitsos",


### PR DESCRIPTION
Change package's name according to JSON standard and to avoid errors running the `yarn install` command.

* Error Fixed
![Screen Shot 2020-03-25 at 3 40 06 PM](https://user-images.githubusercontent.com/1456388/77583107-7dabd700-6eae-11ea-9696-7cdc14343651.png)
